### PR TITLE
adds ncat to the image

### DIFF
--- a/build-images.bash
+++ b/build-images.bash
@@ -15,6 +15,7 @@ do
     p) PUSH=1;;
     *) echo "Invalid option: -$opt";;
   esac
+  shift
 done
 
 if [ $# -lt 1 ];

--- a/fd2dev/Dockerfile
+++ b/fd2dev/Dockerfile
@@ -10,7 +10,8 @@ RUN apt-get update \
   && apt-get install --no-install-recommends -y \ 
      build-essential \
      zip \
-     jq
+     jq \
+     ncat
 
 # Install node/npm
 RUN curl -sL https://deb.nodesource.com/setup_18.x -o /tmp/nodesource_setup.sh \

--- a/fd2dev/repo.txt
+++ b/fd2dev/repo.txt
@@ -1,1 +1,1 @@
-fd2dev:fd2.10
+fd2dev:fd2.11


### PR DESCRIPTION
ncat will be used to support the new Codespaces launch for the dev environment.  A codespace times out after a set period with no interaction with the codespace in the browser.  However, the FD2 dev environment runs in vnc, thus a developer will not need to interact directly with the codespace.  So to keep the codespace alive while the developer is using the codespace (via noVNC or VNC), a `ncat` process will be run in the `fd2_dev` container that sends a heartbeat back to an echo server (also using ncat) that is run in the codespace devcontainer. The output of that echo server within the codespace counts as interactivity and keeps the codespace alive. 